### PR TITLE
fixed 2 sidebar styling errors

### DIFF
--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Fixed error #1 for inconsistent sidebar styling

After inspecting the page I found what seemed like a typo in the class "sidebar-body" and "sidebar-title" where the "-" was replaced by "_". 
I tracked the error to publify_core/app/views/archives_sidebar/_content.html.erb and fixed the class name.