### PR TITLE
Post tags correctly #2

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]')[0].value);
 }
 
 function doneTyping () {

--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -77,6 +77,7 @@ function tag_manager() {
 
 function save_article_tags() {
   $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]')[0].value);
+  
 }
 
 function doneTyping () {

--- a/publify_core/app/views/archives_sidebar/_content.html.erb
+++ b/publify_core/app/views/archives_sidebar/_content.html.erb
@@ -1,6 +1,6 @@
 <% unless sidebar.archives.blank? %>
-  <h3 class="sidebar_title"><%= sidebar.title %></h3>
-  <div class="sidebar_body">
+  <h3 class="sidebar-title"><%= sidebar.title %></h3>
+  <div class="sidebar-body">
     <ul id="archives">
       <% sidebar.archives.each do |month| %>
         <% counter = sidebar.show_count ? "<em>(#{month[:article_count]})</em>" : "" %>


### PR DESCRIPTION
Explanation:

On publish button click, the method "save_article_tags" gets called which saves the tag in db. So identified that the problematic area is here. In console, inspected that input tag element and noted that ("[0].value") was missing at the end to fetch the actual tags value in the input tag. 

I added new tags and it gets displayed successfully.