### PR TITLE
fixed post tags

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -71,7 +71,7 @@ function tag_manager() {
     limit: 15,
     prefetch: '/admin/content/auto_complete_for_article_keywords'
   }).on('typeahead:selected', function (e, d) {
-    tagApi.tagsManager("pushTag", d.value)
+    tagApi.tagsManager("pushTag", d.value);
   });
 }
 

--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -71,12 +71,12 @@ function tag_manager() {
     limit: 15,
     prefetch: '/admin/content/auto_complete_for_article_keywords'
   }).on('typeahead:selected', function (e, d) {
-    tagApi.tagsManager("pushTag", d.value);
+    tagApi.tagsManager("pushTag", d.value)
   });
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {

--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -71,7 +71,7 @@ function tag_manager() {
     limit: 15,
     prefetch: '/admin/content/auto_complete_for_article_keywords'
   }).on('typeahead:selected', function (e, d) {
-    tagApi.tagsManager("pushTag", d.value);
+    tagApi.tagsManager("pushTag", d.value)
   });
 }
 


### PR DESCRIPTION
Fixed error #2 for post tags

The error was in publify_core/app/assets/javascript/publify_admin.js file in the function save_article_tags.
When submitting, the form was set to pass the entire input as the value of the form. It only needed to pass that inputs value instead. It only needed .val() added to the end:
$('#article_form').find('input[name="hidden-article[keywords]"]').val() 