### PR TITLE
#3 Find and hide spinner after the result gets displayed

### DIFF
--- a/publify_core/app/assets/javascripts/spinnable.js
+++ b/publify_core/app/assets/javascripts/spinnable.js
@@ -1,5 +1,5 @@
 // Show and hide spinners on Ajax requests.
 $(document).ready(function(){
   $('form.spinnable').on('ajax:before', function(evt, xhr, status){ $('#spinner').show();})
-  $('form.spinnable').on('ajax:after', function(evt, xhr, status){ $('#spinner').hide();})
+  $('form.spinnable').on('ajax:success', function(evt, xhr, status){ $('#spinner').hide();})
 });

--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,1 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").hide();

--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,2 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();
+$("#spinner").hide();


### PR DESCRIPTION
#3 Find and hide spinner 
Explanation:

1) Found the form which contains the search bar.
2) Found the class name "spinnable" in the form.
3) Searched "spinnable" globally and found a "spinnable.js" file.
4) There were 2 ajax calls. (ajax:before) & (ajax:after). Changed the "after" to "success" because thats the keyword for ajax on success.
5)  Also realised that the spinner.show() in index.js.erb is no longer required if these 2 ajax calls are correct. So deleted that too. Tested it. it worked.