### PR TITLE
have value of tags string show

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,8 +76,10 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
+
 
 function doneTyping () {
   $( "#save-bar").fadeIn(2000, function() {


### PR DESCRIPTION
Fixed the issue of the saved tag strings viewed as objects

#2 

the .val method for the save_article_tags function is trying to get the value of objects. now set to getting the values of what is entered into the input line