### PR TITLE
fixed tag name error for creating new articles

### DIFF
--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -65,7 +65,7 @@ function tag_manager() {
   var tagApi = jQuery("#article_keywords").tagsManager({
     prefilled: $('#article_keywords').val()
   });
-
+  
   jQuery("#article_keywords").typeahead({
     name: 'tags',
     limit: 15,
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {

--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -65,7 +65,7 @@ function tag_manager() {
   var tagApi = jQuery("#article_keywords").tagsManager({
     prefilled: $('#article_keywords').val()
   });
- 
+
   jQuery("#article_keywords").typeahead({
     name: 'tags',
     limit: 15,

--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -65,7 +65,7 @@ function tag_manager() {
   var tagApi = jQuery("#article_keywords").tagsManager({
     prefilled: $('#article_keywords').val()
   });
-  
+ 
   jQuery("#article_keywords").typeahead({
     name: 'tags',
     limit: 15,


### PR DESCRIPTION
#2 

The "save_article_tags" method has been resolved to correctly save tags used in creating new articles/posts.

The bug of new articles containing the string "object" instead of the selected tag name was resolved by modifying file name publify_core/app/assets/javascripts/publify_admin.js to add the method for returning the value of an object, "val()",  to the results of the ".find" method on line 79.   

New articles now have the correct tags names shown when created.
