### PR TITLE
corrected month calculation

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,0 +1,1 @@
+continue

--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = (entry.month.to_i) || 12
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
#4 Explanation 

1.  Since the issue is with archives, visited archives view file (_content.html.erb).
2.  There was a link_to year and month in that file.
3.  Checked where that year and month is getting computed and found it in the model file. 
     (archives_sidebar.rb)
4.  Month number is calculated wrongly in archives_sidebar.rb file as (month % 12)+1 in parse 
     method.
5.  Changed that as month = (entry.month.to_i) || 12 and it worked. This made the months also to be 
     sorted which fixes the issue #5 

