### PR TITLE
hide spinner after search

### DIFF
--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,3 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
 $("#spinner").show();
+$("#spinner").hide();


### PR DESCRIPTION
#3 Find and hide spinner after results are displayed
The file (index.js.erb) was missing the necessary code to hide the spinner after the results are displayed