### PR TITLE
fixed problem2, added the missing syntax word Val

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -466,4 +466,4 @@ DEPENDENCIES
   web-console (~> 3.0)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.1

--- a/publify_core/app/assets/javascripts/publify_admin.js
+++ b/publify_core/app/assets/javascripts/publify_admin.js
@@ -76,7 +76,7 @@ function tag_manager() {
 }
 
 function save_article_tags() {
-  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]'));
+  $('#article_keywords').val($('#article_form').find('input[name="hidden-article[keywords]"]').val());
 }
 
 function doneTyping () {


### PR DESCRIPTION
This PR fixes issue #2 

I found the publify_admin.js file error. It was missing the "Val" to show the value of the form.
