### PR TITLE
fixed the problem #4, deleted spare number 1 at file archives_sidebar

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = entry.month.to_i % 12
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
This PR fixes issue #4 

I globally searched keyword "archives", then I noticed that there were extra "1" at line 33 of file archives_sidebar.rb. That is why our new post shows to the month next. I deleted the spare part, and It works.  