### PR TITLE
fixed load spinner

### DIFF
--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,2 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();
+$("#spinner").hide();


### PR DESCRIPTION
Fixed error #3 

In publify_core/app/views/admin/content/index.js.erb the spinner was set to show after search completes: $("#spinner").show(); fixed it to $("#spinner").hide();