### PR TITLE
changed show method to hide method on id spinner

### DIFF
--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,2 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();
+$("#spinner").hide();


### PR DESCRIPTION
#3 

The spinner would still show after searches were made.  Changing the show method on line 2 of the file publify_core/app/views/admin/content/index.js.erb to the hide method is the proposed solution.  