### PR TITLE
issue- #3 - fix to spinner not going away after search

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -466,4 +466,4 @@ DEPENDENCIES
   web-console (~> 3.0)
 
 BUNDLED WITH
-   1.16.0.pre.2
+   1.16.1

--- a/publify_core/app/views/admin/content/index.js.erb
+++ b/publify_core/app/views/admin/content/index.js.erb
@@ -1,2 +1,2 @@
 $("#articleList").html('<%= raw escape_javascript(render(partial: "article_list", locals: { articles: @articles })) %>');
-$("#spinner").show();
+$("#spinner").hide();


### PR DESCRIPTION
#3 
in `/publify_core/app/views/admin/content/index.js.erb` it seems that the spinner needs to be changed to .hide() instead of .show() after the articleList finishes rendering 

as far as the change in the gemfile.lock, not really sure what happened with that. I was messing with the better_erros gem and did bundle install a few times so maybe it got changed as I was changing the normal gemfile and did not go back to its original instance after I reverted my changes in the gemfile and ran bundle install. 
