### PR TITLE
fixed feb no posts and sidebar_title archives being out of synch

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
#4 

1.) searched web page for element containing ul of archives per months
2.) run global search led to to the archive sidebar ul located in app/models/archives_sidebar.rb
3.) iterating logic of months had unnecessary modulus operator on line 33
4.) changed line 33 to iterate through all months without extra modulus configurations
5.) monthly archives now at correct chronological order. and feb has no empty post 