### PR TITLE
chronological order of monthly archives fixed with the same code chan…

### DIFF
--- a/publify_core/app/models/archives_sidebar.rb
+++ b/publify_core/app/models/archives_sidebar.rb
@@ -30,7 +30,7 @@ class ArchivesSidebar < Sidebar
     article_counts = Content.find_by_sql(["select count(*) as count, #{date_func} from contents where type='Article' and published = ? and published_at < ? group by year,month order by year desc,month desc limit ? ", true, Time.now, count.to_i])
 
     @archives = article_counts.map do |entry|
-      month = (entry.month.to_i % 12) + 1
+      month = entry.month.to_i
       year = entry.year.to_i
       {
         name: I18n.l(Date.new(year, month), format: '%B %Y'),


### PR DESCRIPTION
#5 

1.) I realized the changes made in the #4 fix fixed the problem addressed for number 5

2.) Removed unnecessary modulus and + 1 month order logic to the iteration of list of monthly archives) 

3.) performed same alteration to line 33 of archives_sidebar.rb

Now monthly archives are being iterated in normal chronological order (.to_i)  